### PR TITLE
feat: /list ページを Chakra UI で刷新

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  compiler: {
+    emotion: true,
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,11 @@
       "name": "ai-sandbox",
       "version": "0.1.0",
       "dependencies": {
+        "@chakra-ui/react": "^3.21.1",
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
         "@types/papaparse": "^5.3.16",
+        "framer-motion": "^12.19.2",
         "next": "15.3.4",
         "papaparse": "^5.5.3",
         "react": "^19.0.0",
@@ -22,6 +26,236 @@
         "eslint": "^9",
         "eslint-config-next": "15.3.4",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@ark-ui/react": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@ark-ui/react/-/react-5.15.4.tgz",
+      "integrity": "sha512-+xBKqxmt0JHewOsYsHXtedcdPsPZirAwd9y80JpyYfp8bSpIhmombLTjh0Ue9ktKPr7LdoZhV7qcX1TNrX4grg==",
+      "license": "MIT",
+      "dependencies": {
+        "@internationalized/date": "3.8.2",
+        "@zag-js/accordion": "1.17.4",
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/angle-slider": "1.17.4",
+        "@zag-js/auto-resize": "1.17.4",
+        "@zag-js/avatar": "1.17.4",
+        "@zag-js/carousel": "1.17.4",
+        "@zag-js/checkbox": "1.17.4",
+        "@zag-js/clipboard": "1.17.4",
+        "@zag-js/collapsible": "1.17.4",
+        "@zag-js/collection": "1.17.4",
+        "@zag-js/color-picker": "1.17.4",
+        "@zag-js/color-utils": "1.17.4",
+        "@zag-js/combobox": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/date-picker": "1.17.4",
+        "@zag-js/date-utils": "1.17.4",
+        "@zag-js/dialog": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/editable": "1.17.4",
+        "@zag-js/file-upload": "1.17.4",
+        "@zag-js/file-utils": "1.17.4",
+        "@zag-js/floating-panel": "1.17.4",
+        "@zag-js/focus-trap": "1.17.4",
+        "@zag-js/highlight-word": "1.17.4",
+        "@zag-js/hover-card": "1.17.4",
+        "@zag-js/i18n-utils": "1.17.4",
+        "@zag-js/listbox": "1.17.4",
+        "@zag-js/menu": "1.17.4",
+        "@zag-js/number-input": "1.17.4",
+        "@zag-js/pagination": "1.17.4",
+        "@zag-js/password-input": "1.17.4",
+        "@zag-js/pin-input": "1.17.4",
+        "@zag-js/popover": "1.17.4",
+        "@zag-js/presence": "1.17.4",
+        "@zag-js/progress": "1.17.4",
+        "@zag-js/qr-code": "1.17.4",
+        "@zag-js/radio-group": "1.17.4",
+        "@zag-js/rating-group": "1.17.4",
+        "@zag-js/react": "1.17.4",
+        "@zag-js/select": "1.17.4",
+        "@zag-js/signature-pad": "1.17.4",
+        "@zag-js/slider": "1.17.4",
+        "@zag-js/splitter": "1.17.4",
+        "@zag-js/steps": "1.17.4",
+        "@zag-js/switch": "1.17.4",
+        "@zag-js/tabs": "1.17.4",
+        "@zag-js/tags-input": "1.17.4",
+        "@zag-js/time-picker": "1.17.4",
+        "@zag-js/timer": "1.17.4",
+        "@zag-js/toast": "1.17.4",
+        "@zag-js/toggle": "1.17.4",
+        "@zag-js/toggle-group": "1.17.4",
+        "@zag-js/tooltip": "1.17.4",
+        "@zag-js/tour": "1.17.4",
+        "@zag-js/tree-view": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
+      "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.27.5",
+        "@babel/types": "^7.27.3",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.7.tgz",
+      "integrity": "sha512-qnzXzDXdr/po3bOTbTIQZ7+TxNKxpkN5IifVLXS+r7qwynkZfPyjZfE7hCXbo7IoO9TNcSyibgONsf2HauUd3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.7.tgz",
+      "integrity": "sha512-X6ZlfR/O/s5EQ/SnUSLzr+6kGnkg8HXGMzpgsMsrJVcfDtH1vIp6ctCN4eZ1LS5c0+te5Cb6Y514fASjMRJ1nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.27.5",
+        "@babel/parser": "^7.27.7",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.7",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.27.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.7.tgz",
+      "integrity": "sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@chakra-ui/react": {
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-3.21.1.tgz",
+      "integrity": "sha512-tc8SAeOZbOeOSY+BROE6o1FyzoS8sAuC6TAwlfUCZWhv9CMsxBisC88D4WI/puwnZVfUbzzhdVEQmWkCbJK6ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@ark-ui/react": "5.15.4",
+        "@emotion/is-prop-valid": "1.3.1",
+        "@emotion/serialize": "1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "1.2.0",
+        "@emotion/utils": "1.4.2",
+        "@pandacss/is-valid-prop": "0.54.0",
+        "csstype": "3.1.3",
+        "fast-safe-stringify": "2.1.1"
+      },
+      "peerDependencies": {
+        "@emotion/react": ">=11",
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -53,6 +287,152 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
+      "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
@@ -196,6 +576,31 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.2.tgz",
+      "integrity": "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.1.tgz",
+      "integrity": "sha512-cwsmW/zyw5ltYTUeeYJ60CnQuPqmGwuGVhG9w0PRaRKkAyi38BT5CKrpIbb+jtahSwUl04cWzSx9ZOIxeS6RsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.1",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -633,6 +1038,72 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@internationalized/date": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.2.tgz",
+      "integrity": "sha512-/wENk7CbvLbkUvX1tu0mwq49CVkkWpkXubGel6birjRPyo6uQ4nQpnq5xZu823zRCwwn82zgHrvgF1vZyvmVgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.3.tgz",
+      "integrity": "sha512-p+Zh1sb6EfrfVaS86jlHGQ9HA66fJhV9x5LiE5vCbZtXEHAuhcmUZUdZ4WrFpUBfNalr2OkAJI5AcKEQF+Lebw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz",
@@ -823,6 +1294,11 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@pandacss/is-valid-prop": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@pandacss/is-valid-prop/-/is-valid-prop-0.54.0.tgz",
+      "integrity": "sha512-UhRgg1k9VKRCBAHl+XUK3lvN0k9bYifzYGZOqajDid4L1DyU813A1L0ZwN4iV9WX5TX3PfUugqtgG9LnIeFGBQ=="
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -892,6 +1368,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.8",
@@ -1433,6 +1915,840 @@
         "win32"
       ]
     },
+    "node_modules/@zag-js/accordion": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/accordion/-/accordion-1.17.4.tgz",
+      "integrity": "sha512-WkzoksfxJjuSdq+hIHCINc6hQtoYo5Nf0SfuInBiehRnoJtVjmpqk8VLxhLWhwFD/KMqz0wtWcM0itUGNpOyiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/anatomy": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-1.17.4.tgz",
+      "integrity": "sha512-EDc7dD5nnr5T3kujMc+EvWIAACZ45cyeKKiPDUCAsmrOAYxIpD+Efh5lvKum6XLIUyUNnkpEVTazVNOeaoZBtQ==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/angle-slider": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/angle-slider/-/angle-slider-1.17.4.tgz",
+      "integrity": "sha512-atke7qq2dd2f4Om4T6k9GYi5bvUdBWDuwDIaBC39Kygyrj8IjShlcyv+QETbX0MaghIhbLBJQuvc+7G3eIMF1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/rect-utils": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/aria-hidden": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/aria-hidden/-/aria-hidden-1.17.4.tgz",
+      "integrity": "sha512-P7aSTINxBwGbDUxhemto10JsajbE+kIzKrPMOWAbIipfFSwPtaN4XJRg2aQHZFBuHNm1n2x87n2TJBwjAlPiNQ==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/auto-resize": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/auto-resize/-/auto-resize-1.17.4.tgz",
+      "integrity": "sha512-kCC0cvuxG/yf28P52waRlz7FaliPrOyPXH+XM+GrznLkC8/TpMeR092G9+oHiYauNESTb+yyQzGgKqW6xFd/Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/avatar": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/avatar/-/avatar-1.17.4.tgz",
+      "integrity": "sha512-+B4esXErOoiYNmHarg9aZWAhUhx6bzoIp31zCMkb6lNUKCDb8hBpFIWYpkgOrPmMaMka2zSYSvpfx6+4zA1Lcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/carousel": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/carousel/-/carousel-1.17.4.tgz",
+      "integrity": "sha512-/n6nK5N9d+j3C+Q5GFnkeX4pMzZY/spKKhAbEMk2MPIHcbX50Ozdn+2MIGz0opAWtVwMXPhbl+WFeoNr8jbiSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/scroll-snap": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/checkbox": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/checkbox/-/checkbox-1.17.4.tgz",
+      "integrity": "sha512-nHrbGhHHUdtvkaJ4jAeCzAG5ioEm719a815oxji2rM1Ei+tCD0mrHCntIeuFejVCGnvR2wFnNJaWaZlES85Vqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/focus-visible": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/clipboard": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/clipboard/-/clipboard-1.17.4.tgz",
+      "integrity": "sha512-WieXgxRCbBayngNSSMMj2zVcR0QO0cT5cZZuYLSn1eTbglo9J4sAX1QyEvHwbZWVt/rEokj3Gdp/Pme6rAQpwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/collapsible": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/collapsible/-/collapsible-1.17.4.tgz",
+      "integrity": "sha512-2bDQYGYoiHWECQPQNeC8ekCshXoXb1i3yY9U3siSyKxMZdBL4VdW5+0UOQoleperbN9NONeEcHW0H10cPofEIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/collection": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/collection/-/collection-1.17.4.tgz",
+      "integrity": "sha512-N4FUhh6avw146IAUKxMj57clXOoN1XjY45ETWJMfahlmmmnttaCKuiiUj57/XIgmt3Vpg2bYIthcyTxeI+K4QQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/color-picker": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/color-picker/-/color-picker-1.17.4.tgz",
+      "integrity": "sha512-Zue+eoBeTyKNiHW8lSN+GMWHWsPdl0yZozuRmtuxpKYnI30SSr6GIs88GCY9Inosxz9RqKx7t7TMxsyJlLiJVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/color-utils": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dismissable": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/popper": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/color-utils": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/color-utils/-/color-utils-1.17.4.tgz",
+      "integrity": "sha512-gasEa7yNMRW3dyJPtSVgZkXB5yrDF21XEaT+x8QLzj7WDutXeCOVPpc1GzBD+DupCcb6mTMUbhYdaf52WQxmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/combobox": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/combobox/-/combobox-1.17.4.tgz",
+      "integrity": "sha512-E7mDsVEcIVbRUUIzsI8+OfXyTdPCih60/g7SRd5Mu8cLnzOxdC4tmeoIY+42otPr0e1bieVMjUXTEKR7wvQuAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/aria-hidden": "1.17.4",
+        "@zag-js/collection": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dismissable": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/popper": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/core": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/core/-/core-1.17.4.tgz",
+      "integrity": "sha512-DIL2MXMLBYKR3pnjGGodiEUkY+ST/J81gtIJ32bLYxWWiMeX0SoPIvDZ9tqDHub9Kkd5CF07onXHkdAmB9Djrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/date-picker": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/date-picker/-/date-picker-1.17.4.tgz",
+      "integrity": "sha512-yNYLFlNnmBI+9gzHmrGrDsGSeHa8cj6+pWhNutIVAT9pyEmg/6AciFndL5+P9bolKo59qtXLpX8libxZ4wLr2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/date-utils": "1.17.4",
+        "@zag-js/dismissable": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/live-region": "1.17.4",
+        "@zag-js/popper": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      },
+      "peerDependencies": {
+        "@internationalized/date": ">=3.0.0"
+      }
+    },
+    "node_modules/@zag-js/date-utils": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/date-utils/-/date-utils-1.17.4.tgz",
+      "integrity": "sha512-kPw7GLnj560NdUpXJ1SeoJkNSIddZBa+Sd2fPlyDwqxB5lptqNeRK9FcascRL12PgI7EeM7/R9MVTkTPGdQNjg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@internationalized/date": ">=3.0.0"
+      }
+    },
+    "node_modules/@zag-js/dialog": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/dialog/-/dialog-1.17.4.tgz",
+      "integrity": "sha512-UCTcGlAlbTSS2Po5XvOOl7FiLba5+kh0Vltz8NAZUNn4e87LeitQVTW68k/pxa2nnnaKfPN6CsAWYQ21aZOcwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/aria-hidden": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dismissable": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/focus-trap": "1.17.4",
+        "@zag-js/remove-scroll": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/dismissable": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/dismissable/-/dismissable-1.17.4.tgz",
+      "integrity": "sha512-LkFdUz2Ay3D/CsSjQSVjxQwzH6U5rU6cvEcUTOM90RUSozuV2pAK5NnI3JH3jAy1USlpTbjxHL+2bdep2jkAEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/interact-outside": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/dom-query": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.17.4.tgz",
+      "integrity": "sha512-1fNDCWkHRZXB4dD2hoiyMy0cSkrB/u4fur3To5sOKteka5e9om1/YdbYxXNLmVfeTiC/SJtWNelXP7c/8uDwOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/types": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/editable": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/editable/-/editable-1.17.4.tgz",
+      "integrity": "sha512-qTfvrhbHtfvFZv3l+qAlweOpWyzDwYRQ1xrI+Sc8pCHhml6QiZ1UFUpYbiQWPn7dqdzBEVUIhjzDX4lzjsWGSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/interact-outside": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/file-upload": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/file-upload/-/file-upload-1.17.4.tgz",
+      "integrity": "sha512-onV7jN2l9oXcKAuO/KY0TNcqyaFroQ8JjY+QxOOrZEmhvo48h/Lbi0FwBfk3syNWCRK3ihpRQbKOa1lthupGjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/file-utils": "1.17.4",
+        "@zag-js/i18n-utils": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/file-utils": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/file-utils/-/file-utils-1.17.4.tgz",
+      "integrity": "sha512-eg+ywy2qJn+rXz7wBsJc0N0H6qmKEMvxaWtsynBZ+XDbyrEec/aHNRDaM+l5xdFjDKb5/R151nEDXgnBAT8miA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/i18n-utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/floating-panel": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/floating-panel/-/floating-panel-1.17.4.tgz",
+      "integrity": "sha512-YgGP0PybQ0adlW6aOkFaho1tOzSk0rIVhCzsCQmln9mhSYgSCgwMoJIqfsFTLVpKB7TO155okOh5kwelH75Jfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dismissable": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/popper": "1.17.4",
+        "@zag-js/rect-utils": "1.17.4",
+        "@zag-js/store": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/focus-trap": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-trap/-/focus-trap-1.17.4.tgz",
+      "integrity": "sha512-6exU3DOkyqE2LSRydhgQIho/XhNOvQ35AEbYN81I6yniJPARbkGmDcQaKHZXSL7+tAe0ynX09yfVo4Cskio8Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/focus-visible": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.17.4.tgz",
+      "integrity": "sha512-9P1GtsFqbuLcplwK/Y7MdnQz9NipYUjef8PS2/duQzRf3UM99/zu1ZbRqwNIW/Tf5ztvet3+dMBAN5HEyYW0Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/highlight-word": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/highlight-word/-/highlight-word-1.17.4.tgz",
+      "integrity": "sha512-uBK/5OsopYE5qBjkIoQuqvgd6CTnKpttt4+ODFjPV0NPImgcDuqBT1KlFZZZEPZ58fu1TtNU6hNVKHmZ4EzUnw==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/hover-card": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/hover-card/-/hover-card-1.17.4.tgz",
+      "integrity": "sha512-yOVqj2KUxcMZx6B0LpkMRa1q736eVUXTzQD6Keh4cKxtnCFE+ydYVv70xHL4CLWFqz6+PFRYApgzd05IIbff7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dismissable": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/popper": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/i18n-utils": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/i18n-utils/-/i18n-utils-1.17.4.tgz",
+      "integrity": "sha512-HiRKMQGaZUpjqekq1h1UlMqquIBnQYSiGpW9vWCUbKs5hr7z3VIgJtKoxdCsBkno7vBEejl316DIIDh3N2qbeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/interact-outside": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/interact-outside/-/interact-outside-1.17.4.tgz",
+      "integrity": "sha512-jd7/4V7ESS6FJILPWIm5CmXVR+maZ4fQmQUPV56WOURKdl2LZ2bPgfjvEaVI9BTm7qPTML6O55xgB87rS/sXlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/listbox": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/listbox/-/listbox-1.17.4.tgz",
+      "integrity": "sha512-14OReAbUZNEYjy2eBPqI7FUxts0kTjQS268aukfzLvHcJHAHTcP9ru7XMftZlPbQBofPGr/lSLhIa4NZJF3vrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/collection": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/focus-visible": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/live-region": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/live-region/-/live-region-1.17.4.tgz",
+      "integrity": "sha512-fP2f6C6vEcWydvhYKMYWaVu8tqyiCnKJx8auJ2zL/yZGLz/W3xDdRRqHJCfneilN7m8C6tJhWBBZm5Th22bGmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/menu": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/menu/-/menu-1.17.4.tgz",
+      "integrity": "sha512-KzpvU/rPiPFDexcD+RmcLhPOII5SPgGSSdidpz3pTBy8yEwnwOSoN0PGHm8WnOD4US2wZOHvOqR+Rov8IbmKWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dismissable": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/popper": "1.17.4",
+        "@zag-js/rect-utils": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/number-input": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/number-input/-/number-input-1.17.4.tgz",
+      "integrity": "sha512-lyrZwr3X1wicL8MThZvu4JH5pwldYO2gKQ+CVgMTx6H2epQNVJJ9i8v/+buUNB9/2ufjUV0MaxQ2fuGTXyjAKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@internationalized/number": "3.6.3",
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/pagination": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/pagination/-/pagination-1.17.4.tgz",
+      "integrity": "sha512-yTOcwRdJ0CozEzw0Q+lAUkpWUERFVCCSx9qqIAGqF5jEZSWefUWMQVcPRqupLQ51mhCXdt+wDDh2mTY6Mr+L3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/password-input": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/password-input/-/password-input-1.17.4.tgz",
+      "integrity": "sha512-h77V18+KBvZHUcARnr+Qw+P5vGvvSC9UMzjnE2SpMIpyvOIr1Fp+4TCGKVEIIsWR0LzWnK79UNExVj1Th3t1TQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/pin-input": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/pin-input/-/pin-input-1.17.4.tgz",
+      "integrity": "sha512-k2rhmS0oAPUE93DgdHtV7HkpBvTj3iGvUusVwmifE42ct1VnuuedXHKlicGbJ2ZXWelXmKd5675LHfwmF68h2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/popover": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/popover/-/popover-1.17.4.tgz",
+      "integrity": "sha512-uDRfw5/F3FPeanOJbXnVmk5c+RFFkQozZ6dn3qdnynWn1sLh56Kf5Ys4X+MQInxqUKdtDCb7cO2tfkAZXE5ZOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/aria-hidden": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dismissable": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/focus-trap": "1.17.4",
+        "@zag-js/popper": "1.17.4",
+        "@zag-js/remove-scroll": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/popper": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/popper/-/popper-1.17.4.tgz",
+      "integrity": "sha512-ZdlDcaBzDx4XUzicTviaCP0Q6W1AXwRzdPVO2TzosqQyyn/tYqEfcJePYu9XVsr1Y6bkume4Pt0ucuRN+kUeYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "1.7.1",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/presence": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/presence/-/presence-1.17.4.tgz",
+      "integrity": "sha512-xFEITSvZjoNYh3Ea+48tFqwwsOtSeEa27c3GOa1ToCTs0J+7SrP19bj5w7Hnbk5cGY/4P5OD8OiMKvkPughjEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/progress": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/progress/-/progress-1.17.4.tgz",
+      "integrity": "sha512-1FWUIizd8OMcK+0uUA/6ly3VJd5eHeOZkXC4lIWDGGwLhfEv2Lm+pgF5Ix5u1mtcmawBbhpkSlYjc1CbsjUTQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/qr-code": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/qr-code/-/qr-code-1.17.4.tgz",
+      "integrity": "sha512-z2FLUlGCLmKcNyXCdeWJkovLo4NvFdRAe43psn0M8rhd470rYCzol1/86s2G72DjqUT0ZwadkfgRjLfaLHkYdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4",
+        "proxy-memoize": "3.0.1",
+        "uqr": "0.1.2"
+      }
+    },
+    "node_modules/@zag-js/radio-group": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/radio-group/-/radio-group-1.17.4.tgz",
+      "integrity": "sha512-/u9ugWth+FPu3W1VUTuBIVq3TbJZMLYF8cFPhvTgIjBvbQw9Oe+TW+WywyH1z7Oaz03e4IYhW445sWGoC9TNvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/focus-visible": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/rating-group": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/rating-group/-/rating-group-1.17.4.tgz",
+      "integrity": "sha512-5KQdf+CLX3RzCu7Bj8Xn7AKeDU+sxCjxCcbjs8VviLl6Rj/OaFUoUomZFf/wLsJLY1tqk6PD7dX4NczY7YC2YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/react": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/react/-/react-1.17.4.tgz",
+      "integrity": "sha512-43TEe1Afjh1RR3Byxib/jZ2Wn4UVdZY5Irx5v3tnp8NY8BFeswPhP28e6W2NT4c/UZoWeRxYlXDdrRS2p8L8Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/core": "1.17.4",
+        "@zag-js/store": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@zag-js/rect-utils": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/rect-utils/-/rect-utils-1.17.4.tgz",
+      "integrity": "sha512-DiYNOwtVek9qwtbV906zjNpM8dmJL4sp131rPRgRStTg8MHpfW2PUOaxFklKh9/ykFwPDu6rx7kQ9Y2P4ez/xg==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/remove-scroll": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/remove-scroll/-/remove-scroll-1.17.4.tgz",
+      "integrity": "sha512-EY+N1UodKfu2omYknbWfv+33pljfVW5ZX01iuSlTng3Vx5Zn6xlQCTxpVWvDidACEN6jjBn00QFbGWEhDDBpdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/scroll-snap": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/scroll-snap/-/scroll-snap-1.17.4.tgz",
+      "integrity": "sha512-bdYtDdJjXcupjoTs5n3Z310wEDrsykgWIKVOy5r4daNp+aH99YHBvINt0BUzjfyCpoEH0KvM9KwKlwOhq7XUNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/select": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/select/-/select-1.17.4.tgz",
+      "integrity": "sha512-Yy/83xydKl/Qz3BoeNCwu964lLRDqoF4fsOWPeOFEN6HHftLD7NNNO7eIqe2Qe84ZBwAeQeZ8cNNI2oYHFc/ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/collection": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dismissable": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/popper": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/signature-pad": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/signature-pad/-/signature-pad-1.17.4.tgz",
+      "integrity": "sha512-nGv9uBNkq+jrLfdN+wuINA+ch0jZs/m1UUDcyUvpRfQa/AlkNdv9oC8p6KUJwNhunTQN6E2RCZqO43q49ioEtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4",
+        "perfect-freehand": "^1.2.2"
+      }
+    },
+    "node_modules/@zag-js/slider": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/slider/-/slider-1.17.4.tgz",
+      "integrity": "sha512-Iq3pgLmJIvmQXaUm/+Xt1/s1IV1p73E7ySbThdZ8EADDn60m5ESVTwEymK9jnH10hpXuxDvI1GcbWPOTrIxwYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/splitter": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/splitter/-/splitter-1.17.4.tgz",
+      "integrity": "sha512-6uThEf+gD0z6Nf6CYvp28I2zjfGW0JOdFAJDpwyqyngvGbO4oPkWPozn8uUmbovQrzhiyUx1C6o5UPDsLgFWhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/steps": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/steps/-/steps-1.17.4.tgz",
+      "integrity": "sha512-MSPtDEkPpQTQ/LTsTRhSeG/P4TCl9b0/nKf/cMT/KlmrK7pTonjkDvux/AQHLxkqZ+tMZYl7qYd/ocdARe1mtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/store": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/store/-/store-1.17.4.tgz",
+      "integrity": "sha512-80i4/ggb2OrZ9+l1EJgYcp8uBy5oJwwae/kzy2/r93P+gotct5/qiyZYrybE8+YhU0u5zPiyjTxH0SILfP9Ofg==",
+      "license": "MIT",
+      "dependencies": {
+        "proxy-compare": "3.0.1"
+      }
+    },
+    "node_modules/@zag-js/switch": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/switch/-/switch-1.17.4.tgz",
+      "integrity": "sha512-d5kBKe+q7V87V6K3BcsfJ1jU2qiJvPLjBumUDFkrzU0E5jweVOOwYrqDzLX8X4cBXk9A2R6U8rYdgGwWDctmWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/focus-visible": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/tabs": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/tabs/-/tabs-1.17.4.tgz",
+      "integrity": "sha512-jvchw7erb8ryQTR92QQyP64nmJPJHCeOr6s09ghYqyNIVI5xgVy5hcfgrE4iMXODJ9CSAMsZHqY7QN5Xq10l3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/tags-input": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/tags-input/-/tags-input-1.17.4.tgz",
+      "integrity": "sha512-BYzvgIdqjv2LZSf5tfRECklCEt9u/uyc4gaGOiEseNIzcyQ9xrg9fq2Yk6Wt8mhWujdCbC/zJS2RB3LdcVePng==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/auto-resize": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/interact-outside": "1.17.4",
+        "@zag-js/live-region": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/time-picker": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/time-picker/-/time-picker-1.17.4.tgz",
+      "integrity": "sha512-HGMIWqmpo2/cybCLNaPuMfRZx/wjkNAJKm33oZJXqwpc6rxWvh8bpEtpEOp7WDwWifthc/6VBUI5Smc+aO6oVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dismissable": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/popper": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      },
+      "peerDependencies": {
+        "@internationalized/date": ">=3.0.0"
+      }
+    },
+    "node_modules/@zag-js/timer": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/timer/-/timer-1.17.4.tgz",
+      "integrity": "sha512-jDUIz4jgZAFqAOra/9Ng3mraMMnh1fTHtUAzFgolzwY6V8l2eAMGX0DrXtoEVqxlh4IGE00xN6Kus9j3NfcUOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/toast": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/toast/-/toast-1.17.4.tgz",
+      "integrity": "sha512-lhu0mhHLpT2DaI9d6BjlE2vJEL9/jFmyPGJ9QG9kkQAxDNtEJLiCJEe12mKs5S9LoxDHJGWGYkF2O/7XwLkDnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dismissable": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/toggle": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/toggle/-/toggle-1.17.4.tgz",
+      "integrity": "sha512-cKggg0TaGErAZmYXWGMHH81Gti+AXLMqT29V7EM2qI2tWQzzsmbDbUVoEQ7iZf8Ng6d/JfsZsLq6biZZHg6KsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/toggle-group": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/toggle-group/-/toggle-group-1.17.4.tgz",
+      "integrity": "sha512-cegFuo8X66MX7b06n6rIJlf4hFDPejmZeq1eSu7co4hVKAfqazBFh6SGsnKdIXhOUo162tFchNuKMkhZU3sWBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/tooltip": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/tooltip/-/tooltip-1.17.4.tgz",
+      "integrity": "sha512-lDRXZjd7anVb4h2ZvDCYYZ+puJZZwry5xi72jY6xhz3vVWX5qfkYjZ/MHuuDk/S+fEY+luWJXJ+cPh+v1zie0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/focus-visible": "1.17.4",
+        "@zag-js/popper": "1.17.4",
+        "@zag-js/store": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/tour": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/tour/-/tour-1.17.4.tgz",
+      "integrity": "sha512-RSnzJLTygsMPUXcMuYY0GWTskfwDsSeyM5Jbn5iMUUphnj/3nCtZttbsA22jnXCYE8bK+/+6PnfdcD0Elysf7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dismissable": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/focus-trap": "1.17.4",
+        "@zag-js/interact-outside": "1.17.4",
+        "@zag-js/popper": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/tree-view": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/tree-view/-/tree-view-1.17.4.tgz",
+      "integrity": "sha512-XRc2DxB/gVrkmS7+ZTJBC8p0G1J+mqtFb5zzRxyNitp+VW7yMsRtAUJ7m5gT5bD71zOkk4fPhwuB+ZZtpPAaMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.17.4",
+        "@zag-js/collection": "1.17.4",
+        "@zag-js/core": "1.17.4",
+        "@zag-js/dom-query": "1.17.4",
+        "@zag-js/types": "1.17.4",
+        "@zag-js/utils": "1.17.4"
+      }
+    },
+    "node_modules/@zag-js/types": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/types/-/types-1.17.4.tgz",
+      "integrity": "sha512-GHE1ykkMeHuIPHkkU1JNcIWMoFH322Yq65S4dhhsEgqMRX3BUHW8ids5e+7WOu9ZSH3PGJdpUXe8+jg3USpwaw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "3.1.3"
+      }
+    },
+    "node_modules/@zag-js/utils": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-1.17.4.tgz",
+      "integrity": "sha512-FXici9HJG1ZBLCmbHO/ed4iurDriDjdx8XOfSD052bu22ViWl5jnO2K77OwagexbXGGAJNhswvDeQg5CSqYbvA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1700,6 +3016,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1790,7 +3121,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1882,6 +3212,28 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1899,8 +3251,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -1963,7 +3314,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2056,6 +3406,21 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-ex/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -2230,7 +3595,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -2688,6 +4052,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -2720,6 +4090,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -2771,11 +4147,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.19.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.19.2.tgz",
+      "integrity": "sha512-0cWMLkYr+i0emeXC4hkLF+5aYpzo32nRdQ0D/5DI460B3O7biQ3l2BpDzIGsAHYuZ0fpBP0DC8XBkVf6RPAlZw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.19.0",
+        "motion-utils": "^12.19.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3012,12 +4414,20 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/ignore": {
@@ -3033,7 +4443,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -3166,7 +4575,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -3481,8 +4889,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3496,11 +4903,29 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -3580,6 +5005,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -3666,11 +5097,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.19.0.tgz",
+      "integrity": "sha512-m96uqq8VbwxFLU0mtmlsIVe8NGGSdpBvBSHbnnOJQxniPaabvVdGgxSamhuDwBsRhwX7xPxdICgVJlOpzn/5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.19.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
+      "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -3952,12 +5397,29 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
@@ -3981,8 +5443,22 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/perfect-freehand": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/perfect-freehand/-/perfect-freehand-1.2.2.tgz",
+      "integrity": "sha512-eh31l019WICQ03pkF3FSzHxB8n07ItqIQ++G5UV8JX0zVOXzgTGCqnRR0jJ2h9U8/2uW4W4mtGJELt9kEV0CFQ==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4057,6 +5533,21 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
+      "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-memoize": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-memoize/-/proxy-memoize-3.0.1.tgz",
+      "integrity": "sha512-VDdG/VYtOgdGkWJx7y0o7p+zArSf2383Isci8C+BP3YXgMYDoPd3cCBjw0JdWb6YBb9sFiOPbAADDVTPJnh+9g==",
+      "license": "MIT",
+      "dependencies": {
+        "proxy-compare": "^3.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4108,8 +5599,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -4157,7 +5647,6 @@
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
@@ -4177,7 +5666,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -4482,6 +5970,15 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4667,6 +6164,12 @@
         }
       }
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4683,7 +6186,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4930,6 +6432,12 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.9.2"
       }
     },
+    "node_modules/uqr": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/uqr/-/uqr-0.1.2.tgz",
+      "integrity": "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==",
+      "license": "MIT"
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5046,6 +6554,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "test": "jest --runInBand src/lib/__tests__/pokemonData.test.ts"
   },
   "dependencies": {
+    "@chakra-ui/react": "^3.21.1",
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
     "@types/papaparse": "^5.3.16",
+    "framer-motion": "^12.19.2",
     "next": "15.3.4",
     "papaparse": "^5.5.3",
     "react": "^19.0.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Providers } from './providers'
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,7 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/src/app/list/page.tsx
+++ b/src/app/list/page.tsx
@@ -1,74 +1,159 @@
+'use client' // For Chakra UI components that use client-side features
+
 import { getPokemonStatsList } from '@/lib/pokemonData';
 import { PokemonStats } from '@/types/pokemon';
 import Link from 'next/link';
-// CSS Modulesのファイルをインポート (存在する場合。なければインラインスタイルやglobals.cssで対応)
-// import styles from './list.module.css';
+import {
+  Box,
+  Heading,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  TableContainer,
+  Alert,
+  AlertIcon,
+  AlertTitle,
+  AlertDescription,
+  Button,
+  Center,
+  Spinner,
+  Container,
+} from '@chakra-ui/react';
+import { useEffect, useState } from 'react'; // For client-side data fetching state
 
-export default async function PokemonListPage() {
-  let pokemonStatsList: PokemonStats[] = [];
-  let error: string | null = null;
+export default function PokemonListPage() {
+  const [pokemonStatsList, setPokemonStatsList] = useState<PokemonStats[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
 
-  try {
-    pokemonStatsList = await getPokemonStatsList();
-  } catch (e: any) {
-    console.error("Failed to load Pokemon data:", e);
-    error = e.message || "ポケモンのデータの読み込みに失敗しました。";
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        setLoading(true);
+        const data = await getPokemonStatsList();
+        setPokemonStatsList(data);
+        setError(null);
+      } catch (e: any) {
+        console.error("Failed to load Pokemon data:", e);
+        setError(e.message || "ポケモンのデータの読み込みに失敗しました。");
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return (
+      <Container centerContent p={8}>
+        <Spinner size="xl" />
+        <Heading as="h2" size="lg" mt={4}>読み込み中...</Heading>
+      </Container>
+    );
   }
 
   if (error) {
     return (
-      <main style={{ padding: '20px' }}>
-        <h1>エラー</h1>
-        <p>{error}</p>
-        <Link href="/">ホームに戻る</Link>
-      </main>
+      <Container centerContent p={8}>
+        <Alert
+          status="error"
+          variant="subtle"
+          flexDirection="column"
+          alignItems="center"
+          justifyContent="center"
+          textAlign="center"
+          height="200px"
+          borderRadius="md"
+        >
+          <AlertIcon boxSize="40px" mr={0} />
+          <AlertTitle mt={4} mb={1} fontSize="lg">
+            エラー
+          </AlertTitle>
+          <AlertDescription maxWidth="sm">
+            {error}
+          </AlertDescription>
+        </Alert>
+        <Button as={Link} href="/" colorScheme="teal" mt={4}>
+          ホームに戻る
+        </Button>
+      </Container>
     );
   }
 
   if (!pokemonStatsList || pokemonStatsList.length === 0) {
     return (
-      <main style={{ padding: '20px' }}>
-        <h1>ポケモン種族値一覧</h1>
-        <p>表示できるポケモンがいません。</p>
-        <Link href="/">ホームに戻る</Link>
-      </main>
+      <Container centerContent p={8}>
+         <Heading as="h1" size="xl" mb={6} textAlign="center">
+          ポケモン種族値一覧
+        </Heading>
+        <Alert
+          status="info"
+          variant="subtle"
+          flexDirection="column"
+          alignItems="center"
+          justifyContent="center"
+          textAlign="center"
+          height="200px"
+          borderRadius="md"
+        >
+          <AlertIcon boxSize="40px" mr={0} />
+          <AlertTitle mt={4} mb={1} fontSize="lg">
+            情報
+          </AlertTitle>
+          <AlertDescription maxWidth="sm">
+            表示できるポケモンがいません。
+          </AlertDescription>
+        </Alert>
+        <Button as={Link} href="/" colorScheme="teal" mt={4}>
+          ホームに戻る
+        </Button>
+      </Container>
     );
   }
 
   return (
-    <main style={{ padding: '20px', fontFamily: 'sans-serif' }}>
-      <h1 style={{ textAlign: 'center', marginBottom: '20px' }}>ポケモン種族値一覧</h1>
-      <table style={{ width: '100%', borderCollapse: 'collapse', boxShadow: '0 2px 4px rgba(0,0,0,0.1)' }}>
-        <thead style={{ backgroundColor: '#f2f2f2' }}>
-          <tr>
-            <th style={{ border: '1px solid #ddd', padding: '10px', textAlign: 'left' }}>図鑑番号</th>
-            <th style={{ border: '1px solid #ddd', padding: '10px', textAlign: 'left' }}>名前</th>
-            <th style={{ border: '1px solid #ddd', padding: '10px', textAlign: 'right' }}>HP</th>
-            <th style={{ border: '1px solid #ddd', padding: '10px', textAlign: 'right' }}>こうげき</th>
-            <th style={{ border: '1px solid #ddd', padding: '10px', textAlign: 'right' }}>ぼうぎょ</th>
-            <th style={{ border: '1px solid #ddd', padding: '10px', textAlign: 'right' }}>とくこう</th>
-            <th style={{ border: '1px solid #ddd', padding: '10px', textAlign: 'right' }}>とくぼう</th>
-            <th style={{ border: '1px solid #ddd', padding: '10px', textAlign: 'right' }}>すばやさ</th>
-          </tr>
-        </thead>
-        <tbody>
-          {pokemonStatsList.map((pokemon) => (
-            <tr key={pokemon.id + pokemon.name} style={{ borderBottom: '1px solid #eee' }}>
-              <td style={{ border: '1px solid #ddd', padding: '10px' }}>{pokemon.id}</td>
-              <td style={{ border: '1px solid #ddd', padding: '10px' }}>{pokemon.name}</td>
-              <td style={{ border: '1px solid #ddd', padding: '10px', textAlign: 'right' }}>{pokemon.hp}</td>
-              <td style={{ border: '1px solid #ddd', padding: '10px', textAlign: 'right' }}>{pokemon.attack}</td>
-              <td style={{ border: '1px solid #ddd', padding: '10px', textAlign: 'right' }}>{pokemon.defense}</td>
-              <td style={{ border: '1px solid #ddd', padding: '10px', textAlign: 'right' }}>{pokemon.specialAttack}</td>
-              <td style={{ border: '1px solid #ddd', padding: '10px', textAlign: 'right' }}>{pokemon.specialDefense}</td>
-              <td style={{ border: '1px solid #ddd', padding: '10px', textAlign: 'right' }}>{pokemon.speed}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      <div style={{ marginTop: '20px', textAlign: 'center' }}>
-        <Link href="/">ホームに戻る</Link>
-      </div>
-    </main>
+    <Box p={5}>
+      <Heading as="h1" size="xl" mb={6} textAlign="center">
+        ポケモン種族値一覧
+      </Heading>
+      <TableContainer borderWidth="1px" borderRadius="lg" boxShadow="lg">
+        <Table variant="striped" colorScheme="teal">
+          <Thead bg="teal.500">
+            <Tr>
+              <Th color="white" textAlign="left" p={4}>図鑑番号</Th>
+              <Th color="white" textAlign="left" p={4}>名前</Th>
+              <Th color="white" isNumeric p={4}>HP</Th>
+              <Th color="white" isNumeric p={4}>こうげき</Th>
+              <Th color="white" isNumeric p={4}>ぼうぎょ</Th>
+              <Th color="white" isNumeric p={4}>とくこう</Th>
+              <Th color="white" isNumeric p={4}>とくぼう</Th>
+              <Th color="white" isNumeric p={4}>すばやさ</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {pokemonStatsList.map((pokemon) => (
+              <Tr key={pokemon.id + pokemon.name}>
+                <Td p={4}>{pokemon.id}</Td>
+                <Td p={4}>{pokemon.name}</Td>
+                <Td isNumeric p={4}>{pokemon.hp}</Td>
+                <Td isNumeric p={4}>{pokemon.attack}</Td>
+                <Td isNumeric p={4}>{pokemon.defense}</Td>
+                <Td isNumeric p={4}>{pokemon.specialAttack}</Td>
+                <Td isNumeric p={4}>{pokemon.specialDefense}</Td>
+                <Td isNumeric p={4}>{pokemon.speed}</Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </TableContainer>
+      <Center mt={6}>
+        <Button as={Link} href="/" colorScheme="teal">
+          ホームに戻る
+        </Button>
+      </Center>
+    </Box>
   );
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { ChakraProvider } from '@chakra-ui/react'
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <ChakraProvider>{children}</ChakraProvider>
+}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { ChakraProvider } from '@chakra-ui/react'
+import { ChakraProvider, defaultSystem } from '@chakra-ui/react'
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  return <ChakraProvider>{children}</ChakraProvider>
+  return <ChakraProvider value={defaultSystem}>{children}</ChakraProvider>
 }


### PR DESCRIPTION
Chakra UI を導入し、/list ページのレイアウトをリッチなものに変更しました。

主な変更点:
- Chakra UI および関連パッケージをインストール
- ChakraProvider をアプリケーション全体に設定
- /list ページを Chakra UI コンポーネント (Table, Heading, Alert, Button等) を使用して再構築
- ローディング、エラー、データなしの状態表示を改善